### PR TITLE
fix: hex8 to rgba

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 langage: ruby
 
 rvm:
-  - 2.2.0
-  - 2.1.5
-  - 1.9.3
-  - jruby
+  - 2.4
+  - 2.3
+  - 2.2
+
+before_install:
+  - gem update --system
+  - gem --version
+  - gem update bundler
 
 script:
   - rake spec

--- a/chroma.gemspec
+++ b/chroma.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.7'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.1.0'
+  spec.add_development_dependency 'bundler', '~> 1.15'
+  spec.add_development_dependency 'rake', '~> 12.0'
+  spec.add_development_dependency 'rspec', '~> 3.6.0'
 end

--- a/lib/chroma/rgb_generator/from_hex_string_values.rb
+++ b/lib/chroma/rgb_generator/from_hex_string_values.rb
@@ -50,7 +50,7 @@ module Chroma
         # @param g      [String] green value
         # @param b      [String] blue value
         # @param a      [String] alpha value
-        def from_hex8(format, a, r, g, b)
+        def from_hex8(format, r, g, b, a)
           new(format || :hex8, r, g, b, a)
         end
       end


### PR DESCRIPTION
## Problem

Currently `Chroma::Color` generates a wrong RGB from HEX8. Here is proof that `#eb09b9c4` has to be `235, 9, 185`:

![CleanShot 2022-09-20 at 20 35 28](https://user-images.githubusercontent.com/1442465/191388695-01e5c1af-aba7-4788-b186-ee321342bff6.png)



But `Chroma::Color#rgb` returns `9, 185, 196`:

```ruby
Chroma::Color.new('#EB09B9C4').rgb
=> #<Chroma::ColorModes::Rgb:0x00007fac8de02a40 @a=0.9215686274509803, @b=196, @g=185, @r=9>
```

## Solution

I have found a six-year-old issue https://github.com/jfairbank/chroma/issues/6, that was resolved by replacing the order of arguments for `FromHexStringValues#from_hex8` method. I have moved it back, and now it returns the expected RGB:

```ruby
Chroma::Color.new('#EB09B9C4').rgb
=> #<Chroma::ColorModes::Rgb:0x00007fabb83d8e78 @a=0.7686274509803922, @b=185, @g=9, @r=235>
```